### PR TITLE
Link change to files.data.gouv for 2022-01

### DIFF
--- a/components/cadastre-etalab.js
+++ b/components/cadastre-etalab.js
@@ -191,7 +191,7 @@ const millesimes = [
   {
     date: '1er janvier 2022',
     path: '2022-01-01',
-    baseUrl: downloadUrls.current,
+    baseUrl: downloadUrls.old,
     formats: [
       {name: 'geojson', granularities: ['communes', 'departements', 'france']},
       {name: 'shp', granularities: ['departements', 'france']},

--- a/components/pci.js
+++ b/components/pci.js
@@ -175,7 +175,7 @@ const millesimes = [
   {
     date: '1er janvier 2022',
     path: '2022-01-01',
-    baseUrl: downloadUrls.current,
+    baseUrl: downloadUrls.old,
     formats: [
       {name: 'edigeo', granularities: ['feuilles', 'departements']},
       {name: 'edigeo-cc', granularities: ['feuilles', 'departements']},


### PR DESCRIPTION
Change link for 2022-à1-01 datasets due to files move from https://cadastre.data.gouv.fr/data/ to https://files.data.gouv.fr/cadastre/ gain disk space on prod